### PR TITLE
feat(analytics): gate GA4 behind cookie consent

### DIFF
--- a/src/components/Analytics.tsx
+++ b/src/components/Analytics.tsx
@@ -3,21 +3,27 @@ import { Helmet } from 'react-helmet-async';
 const GA_ID = import.meta.env.VITE_GA_ID as string | undefined;
 const GSC_VERIFICATION = import.meta.env.VITE_GSC_VERIFICATION as string | undefined;
 
-const Analytics = () => {
+interface AnalyticsProps {
+  /** Load the GA4 cookie-setting script. Gate this on the visitor's consent. */
+  gaEnabled?: boolean;
+}
+
+const Analytics = ({ gaEnabled = false }: AnalyticsProps) => {
   return (
     <>
+      {/* Site-ownership verification is not tracking — always render it. */}
       {GSC_VERIFICATION && (
         <Helmet>
           <meta name="google-site-verification" content={GSC_VERIFICATION} />
         </Helmet>
       )}
-      {GA_ID && (
+      {gaEnabled && GA_ID && (
         <Helmet>
           <script async src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}></script>
           <script>
             {`
               window.dataLayer = window.dataLayer || [];
-              function gtag(){dataLayer.push(arguments);} 
+              function gtag(){dataLayer.push(arguments);}
               gtag('js', new Date());
               gtag('config', '${GA_ID}', { anonymize_ip: true });
             `}
@@ -29,5 +35,3 @@ const Analytics = () => {
 };
 
 export default Analytics;
-
-

--- a/src/components/ConditionalAnalytics.tsx
+++ b/src/components/ConditionalAnalytics.tsx
@@ -1,11 +1,16 @@
 import Analytics from './Analytics';
 import { Analytics as VercelAnalytics } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/react';
+import { useConsent } from '@/hooks/use-consent';
 
 const ConditionalAnalytics = () => {
+  const { hasConsented } = useConsent();
+
   return (
     <>
-      <Analytics />
+      {/* GSC verification always renders; GA4 (sets cookies) only after consent. */}
+      <Analytics gaEnabled={hasConsented} />
+      {/* Vercel Analytics and Speed Insights are cookieless, so they run unconditionally. */}
       <VercelAnalytics />
       <SpeedInsights />
     </>

--- a/src/hooks/use-consent.ts
+++ b/src/hooks/use-consent.ts
@@ -3,6 +3,15 @@ import { useState, useEffect, useCallback } from 'react';
 const CONSENT_STORAGE_KEY = 'noja-cookie-consent';
 const CONSENT_VERSION = 2;
 
+// Module-level subscribers so every useConsent() instance stays in sync.
+// Without this, the banner and the analytics gate hold independent state and
+// acknowledging in one would not load GA in the other until a full reload.
+const listeners = new Set<() => void>();
+
+function notify(): void {
+  listeners.forEach((listener) => listener());
+}
+
 function getStoredAcknowledgement(): boolean {
   if (typeof window === 'undefined') return false;
   try {
@@ -29,12 +38,21 @@ export function useConsent() {
   const [hasConsented, setHasConsented] = useState<boolean>(() => getStoredAcknowledgement());
 
   useEffect(() => {
-    setHasConsented(getStoredAcknowledgement());
+    const sync = () => setHasConsented(getStoredAcknowledgement());
+    sync();
+    listeners.add(sync);
+    // Keep consent consistent across tabs.
+    window.addEventListener('storage', sync);
+    return () => {
+      listeners.delete(sync);
+      window.removeEventListener('storage', sync);
+    };
   }, []);
 
   const acknowledge = useCallback(() => {
     storeAcknowledgement();
     setHasConsented(true);
+    notify();
   }, []);
 
   const resetConsent = useCallback(() => {
@@ -42,6 +60,7 @@ export function useConsent() {
       localStorage.removeItem(CONSENT_STORAGE_KEY);
     }
     setHasConsented(false);
+    notify();
   }, []);
 
   return { hasConsented, acknowledge, resetConsent };


### PR DESCRIPTION
## What & why

GA4 previously loaded on every visit whenever \`VITE_GA_ID\` was set, with **no consent check** — even though the cookie banner and docs implied otherwise. For a Swiss business (FADP/nDSG) that likely receives EU traffic, analytics that set cookies should not run before the visitor acknowledges the banner. This wires GA4 to the existing \`useConsent\` state so the banner actually means something.

## Changes

- **\`Analytics.tsx\`** — takes a \`gaEnabled\` prop (default \`false\`); the GA4 script loads only when \`true\`. **GSC verification stays unconditional** — it's site-ownership, not tracking, and Googlebot never consents, so gating it would break Search Console verification.
- **\`ConditionalAnalytics.tsx\`** — reads \`hasConsented\` and passes it as \`gaEnabled\`. Vercel Analytics + Speed Insights remain unconditional (cookieless).
- **\`use-consent.ts\`** — added a module-level subscriber store + \`storage\`-event listener so the banner and the analytics gate (two separate hook instances) stay in sync, and consent syncs across tabs. Without this, acknowledging wouldn't load GA until a full reload.

## Behavior

- First visit → banner shows, **GA does not load**.
- Acknowledge → GA loads immediately (live, no reload), still with \`anonymize_ip: true\`.
- Opt-in model. The banner still has only an "acknowledge" button (no reject) — that was a deliberate scope choice; ignoring the banner = no GA, which is the compliant default.

## Verification

- \`npm run lint\` — clean (zero warnings)
- \`npx tsc --noEmit\` — clean
- \`npx vite build\` — clean